### PR TITLE
[SK-8958] Fix IOS TypeError LoadError bug on frontend worker

### DIFF
--- a/lib/Api/EvaluationApi.php
+++ b/lib/Api/EvaluationApi.php
@@ -574,7 +574,7 @@ class EvaluationApi
             );
         }
 
-        $resourcePath = '/evaluation/batch';
+        $resourcePath = '/evaluation/batch/';
         $formParams = [];
         $queryParams = [];
         $headerParams = [];


### PR DESCRIPTION
### Description
This attempts to fix the frontend worker TypeError LoadError bug found in production. This Bug seems to happen because of a CORS issue when the app requests `https://features.sidekicker.com/api/v1/evaluation/batch` on a very bad network. From looking at [this thread](https://stackoverflow.com/questions/63141448/safari-fetch-api-cannot-load-due-to-access-control-checks-after-reload), this happens because of a bug on the the way safari handles the preflight check on a cached resource and adding a forward slash to the CORS redirect path to treat the path as a directory seems to be the most practical of the bad workarounds.

### Reference
- JIRA Issue: https://sidekicker.atlassian.net/browse/SK-8958

### Risk
- High